### PR TITLE
fix(controller): allow ingress to cert-manager HTTP01 solver pods

### DIFF
--- a/internal/controller/lms/lmsmoodle_controller.go
+++ b/internal/controller/lms/lmsmoodle_controller.go
@@ -92,6 +92,7 @@ type LMSMoodleReconcilerContext struct {
 	namespace                          *corev1.Namespace
 	lmsMoodleNetpolOmit                bool
 	lmsMoodleDefaultNetpol             *networkingv1.NetworkPolicy
+	lmsMoodleHttp01SolverNetpol        *networkingv1.NetworkPolicy
 }
 
 type LMSMoodleTemplateNotFoundError struct {
@@ -243,6 +244,8 @@ func (r *LMSMoodleReconciler) reconcilePrepare(ctx context.Context) error {
 
 	// define default network policy
 	r.defineLMSMoodleDefaultNetpol()
+	// define http01 solver network policy
+	r.defineLMSMoodleHttp01SolverNetpol()
 
 	// whether LMSMoodle has dependant components
 	if err := r.postgresSpec(); err != nil {
@@ -424,6 +427,17 @@ func (r *LMSMoodleReconciler) reconcilePresent(ctx context.Context) (requeue boo
 		}
 	} else {
 		if err := r.ReconcileCreate(ctx, r.lmsMoodleCtx.lmsMoodle, r.lmsMoodleCtx.lmsMoodleDefaultNetpol); err != nil {
+			return false, err
+		}
+	}
+
+	// Whether http01 solver network policy should be present
+	if r.lmsMoodleCtx.lmsMoodleNetpolOmit {
+		if err := r.ReconcileDeleteDependant(ctx, r.lmsMoodleCtx.lmsMoodle, r.lmsMoodleCtx.lmsMoodleHttp01SolverNetpol); client.IgnoreNotFound(err) != nil {
+			return false, err
+		}
+	} else {
+		if err := r.ReconcileCreate(ctx, r.lmsMoodleCtx.lmsMoodle, r.lmsMoodleCtx.lmsMoodleHttp01SolverNetpol); err != nil {
 			return false, err
 		}
 	}

--- a/internal/controller/lms/util.go
+++ b/internal/controller/lms/util.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -1082,6 +1083,36 @@ func (r *LMSMoodleReconciler) defineLMSMoodleDefaultNetpol() {
 	}
 	r.lmsMoodleCtx.lmsMoodleDefaultNetpol.SetNamespace(r.lmsMoodleCtx.namespaceName)
 	r.lmsMoodleCtx.lmsMoodleDefaultNetpol.SetName(r.lmsMoodleCtx.networkPolicyBaseName + "-netpol")
+}
+
+// defineLMSMoodleHttp01SolverNetpol define network policy allowing ingress to cert-manager HTTP01 solver pods
+func (r *LMSMoodleReconciler) defineLMSMoodleHttp01SolverNetpol() {
+	protocol := corev1.ProtocolTCP
+	port := intstr.FromInt(8089)
+	r.lmsMoodleCtx.lmsMoodleHttp01SolverNetpol = &networkingv1.NetworkPolicy{
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"acme.cert-manager.io/http01-solver": "true",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Protocol: &protocol,
+							Port:     &port,
+						},
+					},
+				},
+			},
+		},
+	}
+	r.lmsMoodleCtx.lmsMoodleHttp01SolverNetpol.SetNamespace(r.lmsMoodleCtx.namespaceName)
+	r.lmsMoodleCtx.lmsMoodleHttp01SolverNetpol.SetName(r.lmsMoodleCtx.networkPolicyBaseName + "-http01-solver-netpol")
 }
 
 // isDependantSuspended whether dependant is suspended


### PR DESCRIPTION
Add a NetworkPolicy that allows ingress traffic on port 8089 to pods labeled acme.cert-manager.io/http01-solver=true in the LMSMoodle namespace. This fixes Let's Encrypt HTTP01 challenges failing when the default deny-all namespace NetworkPolicy is active.

The policy is created alongside the existing default deny-all policy and is removed when lmsMoodleNetpolOmit is set to true.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [ ] Have you tested your changes on all related environments with successful results, as applicable?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)



**What is the current behavior? (link to any open issues here)**



**What is the new behavior (if this is a feature change)?**



**Other information**:
